### PR TITLE
remove cost, link to ORCID APIs public, member #7025

### DIFF
--- a/doc/sphinx-guides/source/installation/oauth2.rst
+++ b/doc/sphinx-guides/source/installation/oauth2.rst
@@ -26,11 +26,11 @@ Identity Provider Side
 Obtain Client ID and Client Secret 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Before OAuth providers will release information about their users (first name, last name, etc.) to your Dataverse installation, you must request a "Client ID" and "Client Secret" from them. In the case of GitHub and Google, this is as simple as clicking a few buttons and there is no cost associated with using their authentication service. ORCID has a free public API that can also be used for authentication and accessing public data. ORCID member API and Microsoft, on the other hand, do not have an automated system for requesting these credentials, and it is not free to use them.
+Before OAuth providers will release information about their users (first name, last name, etc.) to your Dataverse installation, you must request a "Client ID" and "Client Secret" from them. In many cases you can use providers' automated system to request these credentials, but if not, contact the provider for assistance.
 
 URLs to help you request a Client ID and Client Secret from the providers supported by Dataverse are provided below.  For all of these providers, it's a good idea to request the Client ID and Client secret using a generic account, perhaps the one that's associated with the ``:SystemEmail`` you've configured for Dataverse, rather than your own personal Microsoft Azure AD, ORCID, GitHub, or Google account:
 
-- ORCID: https://orcid.org/content/register-client-application-production-trusted-party
+- ORCID: https://orcid.org/content/register-client-application-0
 - Microsoft: https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code
 - GitHub: https://github.com/settings/applications/new via https://developer.github.com/v3/oauth/
 - Google: https://console.developers.google.com/projectselector/apis/credentials via https://developers.google.com/identity/protocols/OAuth2WebServer (pick "OAuth client ID")


### PR DESCRIPTION
This for https://github.com/IQSS/dataverse/pull/7025

The idea is remove any discussion of cost and link to the page on ORCID where you can choose which API you want to use:

<img width="418" alt="Screen Shot 2020-06-29 at 11 19 24 AM" src="https://user-images.githubusercontent.com/21006/86024000-6d9a1b00-b9fa-11ea-91ce-95c5d5101667.png">
